### PR TITLE
feat: add support for an output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ node_modules
 report*.json
 report*.html
 stats.config.js
+output

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Configure `package.json` to run cli tool
 
 // generate-stats.js
 const { cli } = require('@monito/technical-stats')
-cli(__dirname)
+cli(__dirname, 'output') // second parameter is optional, if undefined, it will output in the __dirname folder
+
 ```
 
 Add `.env` file containing Github token.
@@ -129,4 +130,4 @@ module.exports = {
 
 See the [Config type](https://github.com/monito/technical-stats/blob/e7b3fafc3f06aad62f537c646ec2bd8aaf1b21c4/runner/types.ts#L25)
 
-Reports are going to be created in the `./cli` directory
+Reports are going to be created in the `./output` directory

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -25,8 +25,9 @@ export const cli = async (workingDirectory: string, outputDirectory?: string) =>
   const now = new Date()
   const date = `${now.getUTCFullYear()}-${now.getUTCMonth() + 1}-${now.getUTCDate()}`
 
-  saveReport(outputDirectory || workingDirectory, 'report.html', htmlReport)
-  saveReport(outputDirectory || workingDirectory, 'report.json', jsonReport)
-  saveReport(outputDirectory || workingDirectory, `report-${date}.html`, htmlReport)
-  saveReport(outputDirectory || workingDirectory, `report-${date}.json`, jsonReport)
+  const out = outputDirectory || workingDirectory
+  saveReport(out, 'report.html', htmlReport)
+  saveReport(out, 'report.json', jsonReport)
+  saveReport(out, `report-${date}.html`, htmlReport)
+  saveReport(out, `report-${date}.json`, jsonReport)
 }

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -5,8 +5,8 @@ import { run } from '../runner'
 export * from '../runner/plugins'
 export * as utils from '../runner/utils'
 
-function saveReport(workingDirectory: string, fileName: string, fileContent: string) {
-  const outputFile = path.resolve(workingDirectory, fileName)
+function saveReport(directory: string, fileName: string, fileContent: string) {
+  const outputFile = path.resolve(directory, fileName)
   fs.writeFileSync(outputFile, fileContent)
   console.log('Generated report file at: ', fileName)
 }

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -11,7 +11,7 @@ function saveReport(workingDirectory: string, fileName: string, fileContent: str
   console.log('Generated report file at: ', fileName)
 }
 
-export const cli = async (workingDirectory: string) => {
+export const cli = async (workingDirectory: string, outputDirectory?: string) => {
   const configPath = path.resolve(workingDirectory, 'stats.config.js')
   const config = require(configPath)
   const report = await run(config)
@@ -25,8 +25,8 @@ export const cli = async (workingDirectory: string) => {
   const now = new Date()
   const date = `${now.getUTCFullYear()}-${now.getUTCMonth() + 1}-${now.getUTCDate()}`
 
-  saveReport(workingDirectory, 'report.html', htmlReport)
-  saveReport(workingDirectory, 'report.json', jsonReport)
-  saveReport(workingDirectory, `report-${date}.html`, htmlReport)
-  saveReport(workingDirectory, `report-${date}.json`, jsonReport)
+  saveReport(outputDirectory || workingDirectory, 'report.html', htmlReport)
+  saveReport(outputDirectory || workingDirectory, 'report.json', jsonReport)
+  saveReport(outputDirectory || workingDirectory, `report-${date}.html`, htmlReport)
+  saveReport(outputDirectory || workingDirectory, `report-${date}.json`, jsonReport)
 }

--- a/cli/integration.ts
+++ b/cli/integration.ts
@@ -1,3 +1,3 @@
 import { cli } from './index'
 
-cli(__dirname)
+cli(__dirname, 'output')


### PR DESCRIPTION
## Description:

- add support to specify an output folder for reports

## Motivation:

It is helpful to have the choice to generate reports elsewhere than in the `src` folder.